### PR TITLE
Fix heart beat timer with new WisBlock API version

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -299,7 +299,8 @@ void app_event_handler(void)
 		// Reset the standard timer
 		if (g_lorawan_settings.send_repeat_time != 0)
 		{
-			g_task_wakeup_timer.reset();
+			//g_task_wakeup_timer.reset();
+			api_timer_restart(g_lorawan_settings.send_repeat_time);
 		}
 	}
 

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -299,7 +299,6 @@ void app_event_handler(void)
 		// Reset the standard timer
 		if (g_lorawan_settings.send_repeat_time != 0)
 		{
-			//g_task_wakeup_timer.reset();
 			api_timer_restart(g_lorawan_settings.send_repeat_time);
 		}
 	}


### PR DESCRIPTION
This commit allows RAK mappers to work with the new WisBlock API. As software timer is no longer used.
This fixes the heart beat of the mapper.